### PR TITLE
RDBC-497 Fixed: assertion changed - number of indexes created by sample data command is 7

### DIFF
--- a/tests/get_statistics_command_test.go
+++ b/tests/get_statistics_command_test.go
@@ -27,7 +27,7 @@ func getStatisticsCommandTestCanGetStats(t *testing.T, driver *RavenTestDriver) 
 	stats := command.Result
 	assert.NotNil(t, stats)
 	assert.True(t, stats.LastDocEtag > 0)
-	assert.Equal(t, stats.CountOfIndexes, 3)
+	assert.Equal(t, stats.CountOfIndexes, 7)
 	assert.Equal(t, stats.CountOfDocuments, int64(1059))
 	assert.True(t, stats.CountOfRevisionDocuments > 0)
 	assert.Equal(t, stats.CountOfDocumentsConflicts, int64(0))


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-497