### PR TITLE
RDBC-772 Cluster wide transactions

### DIFF
--- a/advanced_session_operations.go
+++ b/advanced_session_operations.go
@@ -227,8 +227,9 @@ func (o *AdvancedSessionOperations) SetMaxNumberOfRequestsPerSession(n int) {
 	o.s.maxNumberOfRequestsPerSession = n
 }
 
-func (o *AdvancedSessionOperations) ClusterTransaction() (*ClusterTransactionOperations, error) {
-	return o.s.GetClusterSession()
+func (o *AdvancedSessionOperations) ClusterTransaction() *ClusterTransactionOperations {
+	clusterSession, _ := o.s.GetClusterSession()
+	return clusterSession
 }
 
 func (o *AdvancedSessionOperations) SetTransactionMode(mode TransactionMode) {

--- a/advanced_session_operations.go
+++ b/advanced_session_operations.go
@@ -227,6 +227,14 @@ func (o *AdvancedSessionOperations) SetMaxNumberOfRequestsPerSession(n int) {
 	o.s.maxNumberOfRequestsPerSession = n
 }
 
+func (o *AdvancedSessionOperations) ClusterTransaction() (*ClusterTransactionOperations, error) {
+	return o.s.GetClusterSession()
+}
+
+func (o *AdvancedSessionOperations) SetTransactionMode(mode TransactionMode) {
+	o.s.transactionMode = mode
+}
+
 /*
 String storeIdentifier();
 boolean isUseOptimisticConcurrency();

--- a/batch_operation.go
+++ b/batch_operation.go
@@ -31,7 +31,7 @@ func (b *BatchOperation) createRequest() (*BatchCommand, error) {
 
 	b.entities = result.entities
 
-	return newBatchCommand(b.session.GetConventions(), result.sessionCommands, result.options, b.session.transactionMode, b.session.disableAtomicDocumentWritesInClusterWideTransaction) //todo disableAtomic!!!
+	return newBatchCommand(b.session.GetConventions(), result.sessionCommands, result.options, b.session.transactionMode, b.session.disableAtomicDocumentWritesInClusterWideTransaction)
 }
 
 func (b *BatchOperation) setResult(serverResult *JSONArrayResult) error {

--- a/batch_operation.go
+++ b/batch_operation.go
@@ -31,10 +31,94 @@ func (b *BatchOperation) createRequest() (*BatchCommand, error) {
 
 	b.entities = result.entities
 
-	return newBatchCommand(b.session.GetConventions(), result.sessionCommands, result.options)
+	return newBatchCommand(b.session.GetConventions(), result.sessionCommands, result.options, b.session.transactionMode, b.session.disableAtomicDocumentWritesInClusterWideTransaction) //todo disableAtomic!!!
 }
 
-func (b *BatchOperation) setResult(result []map[string]interface{}) error {
+func (b *BatchOperation) setResult(serverResult *JSONArrayResult) error {
+	b.session.sessionInfo.lastClusterTransactionIndex = &serverResult.TransactionIndex
+	if b.session.transactionMode == TransactionMode_ClusterWide && serverResult.TransactionIndex <= 0 {
+		url, err := b.session.GetRequestExecutor().GetURL()
+		if err != nil {
+			url = "UNKOWN_URL"
+		}
+		return newIllegalStateError("Cluster transaction was send to a node that is not supporting it.  So it was executed ONLY on the requested node on " + url)
+	}
+
+	result := serverResult.Results
+	if len(result) == 0 {
+		return throwOnNullResult()
+	}
+
+	for commandIndex := 0; commandIndex < b.sessionCommandsCount; commandIndex++ {
+		batchResult := result[commandIndex]
+		if batchResult == nil {
+			return newIllegalArgumentError("batchResult cannot be nil")
+		}
+		typ, _ := jsonGetAsText(batchResult, "Type")
+
+		switch typ {
+		case "PUT":
+			entity := b.entities[commandIndex]
+			documentInfo := getDocumentInfoByEntity(b.session.documentsByEntity, entity)
+			if documentInfo == nil {
+				continue
+			}
+			changeVector := jsonGetAsTextPointer(batchResult, MetadataChangeVector)
+			if changeVector == nil {
+				return newIllegalStateError("PUT response is invalid. @change-vector is missing on " + documentInfo.id)
+			}
+			id, _ := jsonGetAsText(batchResult, MetadataID)
+			if id == "" {
+				return newIllegalStateError("PUT response is invalid. @id is missing on " + documentInfo.id)
+			}
+
+			for propertyName, v := range batchResult {
+				if propertyName == "Type" {
+					continue
+				}
+
+				meta := documentInfo.metadata
+				meta[propertyName] = v
+			}
+
+			documentInfo.id = id
+			documentInfo.changeVector = changeVector
+			doc := documentInfo.document
+			doc[MetadataKey] = documentInfo.metadata
+			documentInfo.metadataInstance = nil
+
+			b.session.documentsByID.add(documentInfo)
+			b.session.generateEntityIDOnTheClient.trySetIdentity(entity, id)
+
+			afterSaveChangesEventArgs := newAfterSaveChangesEventArgs(b.session, documentInfo.id, documentInfo.entity)
+			b.session.onAfterSaveChangesInvoke(afterSaveChangesEventArgs)
+			break
+		case "CompareExchangePUT":
+			index, exist := batchResult["Index"].(float64)
+			if exist == false {
+				return newIllegalStateError("CompareExchangePUT is missing index property.")
+			}
+			key, exist := batchResult["Key"].(string)
+			if exist == false {
+				return newIllegalStateError("CompareExchangePUT is missing key property.")
+			}
+			clusterSession, err := b.session.GetClusterSession()
+			if err != nil {
+				return err
+			}
+
+			clusterSession.updateState(key, int64(index))
+			break
+		default:
+			break
+		}
+
+	}
+
+	return nil
+}
+
+func (b *BatchOperation) setResultOld(result []map[string]interface{}) error {
 	if len(result) == 0 {
 		return throwOnNullResult()
 	}

--- a/command_type.go
+++ b/command_type.go
@@ -14,4 +14,6 @@ const (
 	CommandAttachmentDelete    = "ATTACHMENT_DELETE"
 	CommandClientAnyCommand    = "CLIENT_ANY_COMMAND"
 	CommandClientNotAttachment = "CLIENT_NOT_ATTACHMENT"
+	CompareExchangePut         = "COMPARE_EXCHANGE_PUT"
+	CompareExchangeDelete      = "COMPARE_EXCHANGE_DELETE"
 )

--- a/compare_exchange_session_value.go
+++ b/compare_exchange_session_value.go
@@ -1,0 +1,377 @@
+package ravendb
+
+import "reflect"
+
+type CompareExchangeSessionValue struct {
+	key                  string
+	index                int64
+	value                *CompareExchangeValue
+	changeVector         *string
+	originalValue        *CompareExchangeValue
+	metadataAsDictionary *MetadataAsDictionary
+	state                CompareExchangeValueState
+}
+
+func NewCompareExchangeSessionValue2(value *CompareExchangeValue) (*CompareExchangeSessionValue, error) {
+	var status CompareExchangeValueState
+	if value.GetIndex() >= 0 {
+		status = compareExchangeValueStateNone
+	} else {
+		status = exchangeValueStateMissing
+	}
+
+	cesv, err := NewCompareExchangeSessionValue(value.Key, value.Index, status)
+	if err != nil {
+		return nil, err
+	}
+
+	if value.GetIndex() > 0 {
+
+		cesv.originalValue = NewCompareExchangeValue(value.GetKey(), value.GetIndex(), convertEntityToJSONRaw(value.Value, nil, true))
+	}
+
+	return cesv, nil
+}
+
+func NewCompareExchangeSessionValue(key string, index int64, state CompareExchangeValueState) (*CompareExchangeSessionValue, error) {
+	if len(key) == 0 {
+		return nil, newIllegalStateError("Key cannot be null")
+	}
+
+	return &CompareExchangeSessionValue{
+		key:   key,
+		index: index,
+		state: state,
+	}, nil
+}
+
+func (cesv *CompareExchangeSessionValue) Create(item interface{}) (interface{}, error) {
+	cesv.assertState()
+
+	if cesv.value != nil {
+		return nil, newIllegalStateError("The compare exchange value with key '" + cesv.key + "' is already tracked.")
+	}
+
+	cesv.index = 0
+	cesv.value = NewCompareExchangeValue(cesv.key, cesv.index, item)
+	cesv.state = compareExchangeValueStateCreated
+
+	return cesv.value, nil
+}
+
+func (cesv *CompareExchangeSessionValue) Delete(index int64) {
+	cesv.assertState()
+
+	cesv.index = index
+	cesv.state = compareExchangeValueStateDeleted
+}
+
+func (cesv *CompareExchangeSessionValue) UpdateState(index int64) error {
+	cesv.index = index
+	cesv.state = compareExchangeValueStateNone
+
+	if cesv.originalValue != nil {
+		cesv.originalValue.Index = index
+	}
+
+	if cesv.value != nil {
+		cesv.value.SetIndex(index)
+	}
+
+	return nil
+}
+
+func (cesv *CompareExchangeSessionValue) UpdateValue(value *CompareExchangeValue) error {
+	cesv.index = value.GetIndex()
+	if cesv.index >= 0 {
+		cesv.state = compareExchangeValueStateNone
+	} else {
+		cesv.state = exchangeValueStateMissing
+	}
+
+	cesv.originalValue = value
+
+	if cesv.value != nil {
+		cesv.value.SetIndex(cesv.index)
+
+		if cesv.value.GetValue() != nil {
+			doc, ok := value.GetValue().(map[string]interface{})
+			if ok == false {
+				return newIllegalStateError("Cannot populate")
+			}
+			entity, ok := cesv.value.GetValue().(map[string]interface{})
+			if ok == false {
+				return newIllegalStateError("Cannot populate")
+			}
+
+			for key, val := range doc {
+				entity[key] = val
+			}
+		}
+	}
+
+	return nil // newNotImplementedError("huhu")
+}
+
+func (cesv *CompareExchangeSessionValue) assertState() error {
+	switch cesv.state {
+	case compareExchangeValueStateNone:
+		return nil
+	case exchangeValueStateMissing:
+		return nil
+	case compareExchangeValueStateCreated:
+		return newIllegalStateError("The compare exchange value with key '" + cesv.key + "' was already stored.")
+	case compareExchangeValueStateDeleted:
+		return newIllegalStateError("The compare exchange value with key '" + cesv.key + "' was already deleted.")
+	}
+
+	return nil
+}
+
+func (cesv *CompareExchangeSessionValue) GetValue(clazz reflect.Type, session *InMemoryDocumentSessionOperations) (*CompareExchangeValue, error) {
+	switch cesv.state {
+	case compareExchangeValueStateNone, compareExchangeValueStateCreated:
+		if cesv.value != nil {
+			return cesv.value, nil
+		}
+
+		if cesv.value != nil {
+			return nil, newIllegalStateError("Value cannot be null")
+		}
+
+		var entityObject interface{}
+		if cesv.originalValue != nil && cesv.originalValue.GetValue() != nil {
+			if isPrimitiveOrWrapper(clazz) || clazz.Kind() == reflect.String {
+				originalValueAsMap, isMap := cesv.originalValue.GetValue().(map[string]interface{})
+				if isMap == false {
+					return nil, newIllegalArgumentError("Expected original as map[string]interface{}")
+				}
+
+				jsString, exists := originalValueAsMap[compareExchangeObjectFieldName]
+				if exists == false {
+					return nil, newIllegalArgumentError("Unable to read compare exchange value")
+				}
+
+				entity, err := treeToValue(clazz, jsString)
+				if err != nil {
+					return nil, newIllegalArgumentError("Cannot deserialize compare exchange object")
+				}
+
+				entityObject = entity
+			} else {
+				entityObject = cesv.originalValue.GetValue()
+			}
+		}
+
+		ncev := NewCompareExchangeValue(cesv.key, cesv.index, entityObject)
+		cesv.value = ncev
+		return ncev, nil
+		break
+	case exchangeValueStateMissing, compareExchangeValueStateDeleted:
+		return nil, nil
+	}
+
+	return nil, newIllegalStateError("'compareExchangeValueState' is unknown")
+}
+
+func (cesv *CompareExchangeSessionValue) GetCommand(session *InMemoryDocumentSessionOperations) (ICommandData, error) {
+	if cesv.state == compareExchangeValueStateNone || cesv.state == compareExchangeValueStateCreated {
+		if cesv.value == nil {
+			return nil, nil
+		}
+		var err error
+		////Getting json
+		//entity := cesv.compareExchangeValueToJson(cesv.value.Value, session)
+		//entityJson, ok := entity.(map[string]interface{})
+		//if ok == false {
+		//	return nil, newIllegalArgumentError("Entity should be a dictionary.")
+		//}
+		//
+		//originalEntity := cesv.compareExchangeValueToJson(cesv.originalValue.Value, session)
+		//originalEntityJson, ok := entity.(map[string]interface{})
+		//
+		//if ok {
+		//	areEqual := reflect.DeepEqual(entityJson, originalEntityJson)
+		//	if areEqual == false {
+		//
+		//	}
+		//}
+
+		entity := cesv.compareExchangeValueToJson(cesv.value.Value, session)
+		entityJson, _ := entity.(map[string]interface{})
+
+		var metadata map[string]interface{}
+		if cesv.originalValue != nil && cesv.originalValue.Metadata != nil {
+			metadata = cesv.originalValue.Metadata.metadata
+		}
+
+		metadataHasChanged := false
+
+		if cesv.value.HasMetadata() && cesv.value.Metadata.IsEmpty() == false {
+			if metadata == nil {
+				metadataHasChanged = true
+				metadata, err = cesv.prepareMetadataForPut(cesv.key, cesv.value.GetMetadata(), session.Conventions)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				cesv.validateMetadataForPut(cesv.key, cesv.value.GetMetadata())
+
+				metadataHasChanged = session.UpdateMetadataModificationsTemp(cesv.value.GetMetadata(), metadata)
+			}
+		}
+
+		var entityToInsert map[string]interface{}
+		if entityJson == nil || metadataHasChanged {
+			entityToInsert = convertEntityToJSONRaw(entity, nil, false)
+			entityToInsert = cesv.convertEntity(metadata, entityToInsert)
+			entityJson = entityToInsert
+		}
+
+		newValue := NewCompareExchangeValue(cesv.key, cesv.index, entityJson)
+		hasChanged := cesv.originalValue == nil || metadataHasChanged
+		if hasChanged == false {
+			result, err := newValue.hasChanged(cesv.originalValue)
+			if err != nil {
+				return nil, err
+			}
+			hasChanged = result
+		}
+
+		cesv.originalValue = newValue
+		if hasChanged == false {
+			return nil, nil
+		}
+
+		if entityToInsert == nil {
+			entityToInsert = convertEntityToJSONRaw(entity, nil, false)
+			entityToInsert = cesv.convertEntity(metadata, entityToInsert)
+		}
+
+		return newPutCompareExchangeCommandData(cesv.key, entityToInsert, cesv.index), nil
+	}
+
+	switch cesv.state {
+	case compareExchangeValueStateDeleted:
+
+		return newDeleteCompareExchangeCommandData(cesv.key, cesv.index), nil
+	case exchangeValueStateMissing:
+
+		return nil, nil
+	}
+
+	return nil, newIllegalStateError("Unknown state in GetCommand")
+}
+
+func (cesv *CompareExchangeSessionValue) convertEntity(metadata map[string]interface{}, value map[string]interface{}) map[string]interface{} {
+	objectNode := make(map[string]interface{})
+	objectNode[compareExchangeObjectFieldName] = value
+
+	if cesv.metadataAsDictionary != nil {
+		objectNode[MetadataKey] = cesv.metadataAsDictionary.metadata
+	}
+	return objectNode
+}
+
+type CompareExchangeValueState = int
+
+func (cesv *CompareExchangeSessionValue) compareExchangeValueToJson(value interface{}, session *InMemoryDocumentSessionOperations) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	if isPrimitiveOrWrapper(reflect.TypeOf(value)) || reflect.TypeOf(value).Kind() == reflect.String || isInstanceOfArrayOfInterface(value) {
+		return value
+	}
+
+	return convertEntityToJSONRaw(value, nil, false)
+}
+
+func (cesv *CompareExchangeSessionValue) prepareMetadataForPut(key string, metadataDictionary *MetadataAsDictionary, conventions *DocumentConventions) (map[string]interface{}, error) {
+	error := cesv.validateMetadataForPut(key, metadataDictionary)
+	if error != nil {
+		return nil, error
+	}
+
+	return metadataDictionary.metadata, nil
+}
+
+func (cesv *CompareExchangeSessionValue) validateMetadataForPut(key string, dictionary *MetadataAsDictionary) error {
+	if dictionary.ContainsKey(MetadataExpires) {
+		obj, exists := dictionary.Get(MetadataExpires)
+		if exists == false {
+			return newIllegalStateError("The values of " + MetadataExpires + " metadata for compare exchange '" + key + " is null.")
+		}
+
+		_, isTime := obj.(Time)
+		if isTime == false && reflect.TypeOf(obj).Kind() != reflect.String {
+			return newIllegalStateError("The values of " + MetadataExpires + " metadata for compare exchange '" + key + " is not valid. Use the following type: Date or string.")
+		}
+	}
+
+	return nil
+}
+
+type PutCompareExchangeCommandData struct {
+	*CommandData
+	index    int64
+	document interface{}
+}
+
+//type ICommandData interface {
+//	getId() string
+//	getName() string
+//	getChangeVector() *string
+//	getType() CommandType
+//	serialize(conventions *DocumentConventions) (interface{}, error)
+//}
+
+func (pcecd *PutCompareExchangeCommandData) getId() string            { return pcecd.ID }
+func (pcecd *PutCompareExchangeCommandData) getName() string          { return pcecd.Name }
+func (pcecd *PutCompareExchangeCommandData) getChangeVector() *string { return pcecd.ChangeVector }
+func (pcecd *PutCompareExchangeCommandData) getType() CommandType     { return CompareExchangePut }
+func (pcecd *PutCompareExchangeCommandData) serialize(conventions *DocumentConventions) (interface{}, error) {
+	res := pcecd.baseJSON()
+	res["Index"] = pcecd.index
+	res["Type"] = "CompareExchangePUT"
+	res["Document"] = pcecd.document
+	return res, nil
+}
+
+func newPutCompareExchangeCommandData(key string, value interface{}, index int64) *PutCompareExchangeCommandData {
+	return &PutCompareExchangeCommandData{
+		CommandData: &CommandData{ID: key, Type: "CompareExchangePUT"},
+		index:       index,
+		document:    value,
+	}
+}
+
+type DeleteCompareExchangeCommandData struct {
+	*CommandData
+	index int64
+}
+
+func (pcecd *DeleteCompareExchangeCommandData) getId() string            { return pcecd.ID }
+func (pcecd *DeleteCompareExchangeCommandData) getName() string          { return pcecd.Name }
+func (pcecd *DeleteCompareExchangeCommandData) getChangeVector() *string { return pcecd.ChangeVector }
+func (pcecd *DeleteCompareExchangeCommandData) getType() CommandType     { return CompareExchangeDelete }
+func (pcecd *DeleteCompareExchangeCommandData) serialize(conventions *DocumentConventions) (interface{}, error) {
+	res := pcecd.baseJSON()
+	res["Type"] = "CompareExchangeDELETE"
+	return res, nil
+}
+
+func newDeleteCompareExchangeCommandData(key string, index int64) *DeleteCompareExchangeCommandData {
+	return &DeleteCompareExchangeCommandData{
+		CommandData: &CommandData{ID: key},
+		index:       index,
+	}
+}
+
+const (
+	compareExchangeValueStateNone    = 0
+	compareExchangeValueStateCreated = 1
+	compareExchangeValueStateDeleted = 1 << 1
+	exchangeValueStateMissing        = 1 << 2
+	compareExchangeObjectFieldName   = "Object"
+)

--- a/compare_exchange_session_value.go
+++ b/compare_exchange_session_value.go
@@ -180,22 +180,6 @@ func (cesv *CompareExchangeSessionValue) GetCommand(session *InMemoryDocumentSes
 			return nil, nil
 		}
 		var err error
-		////Getting json
-		//entity := cesv.compareExchangeValueToJson(cesv.value.Value, session)
-		//entityJson, ok := entity.(map[string]interface{})
-		//if ok == false {
-		//	return nil, newIllegalArgumentError("Entity should be a dictionary.")
-		//}
-		//
-		//originalEntity := cesv.compareExchangeValueToJson(cesv.originalValue.Value, session)
-		//originalEntityJson, ok := entity.(map[string]interface{})
-		//
-		//if ok {
-		//	areEqual := reflect.DeepEqual(entityJson, originalEntityJson)
-		//	if areEqual == false {
-		//
-		//	}
-		//}
 
 		entity := cesv.compareExchangeValueToJson(cesv.value.Value, session)
 		entityJson, _ := entity.(map[string]interface{})
@@ -348,7 +332,7 @@ func newPutCompareExchangeCommandData(key string, value interface{}, index int64
 
 type DeleteCompareExchangeCommandData struct {
 	*CommandData
-	index int64
+	Index int64
 }
 
 func (pcecd *DeleteCompareExchangeCommandData) getId() string            { return pcecd.ID }
@@ -357,6 +341,7 @@ func (pcecd *DeleteCompareExchangeCommandData) getChangeVector() *string { retur
 func (pcecd *DeleteCompareExchangeCommandData) getType() CommandType     { return CompareExchangeDelete }
 func (pcecd *DeleteCompareExchangeCommandData) serialize(conventions *DocumentConventions) (interface{}, error) {
 	res := pcecd.baseJSON()
+	res["Index"] = pcecd.Index
 	res["Type"] = "CompareExchangeDELETE"
 	return res, nil
 }
@@ -364,7 +349,7 @@ func (pcecd *DeleteCompareExchangeCommandData) serialize(conventions *DocumentCo
 func newDeleteCompareExchangeCommandData(key string, index int64) *DeleteCompareExchangeCommandData {
 	return &DeleteCompareExchangeCommandData{
 		CommandData: &CommandData{ID: key},
-		index:       index,
+		Index:       index,
 	}
 }
 

--- a/compare_exchange_value.go
+++ b/compare_exchange_value.go
@@ -1,17 +1,89 @@
 package ravendb
 
+import (
+	"bytes"
+	"strings"
+)
+
 // CompareExchangeValue represents value for compare exchange
 type CompareExchangeValue struct {
-	Key   string
-	Index int64
-	Value interface{}
+	Key          string
+	Index        int64
+	Value        interface{}
+	ChangeVector *string
+	Metadata     *MetadataAsDictionary
 }
+
+type ICompareExchangeValue interface {
+	GetKey() string
+	GetIndex() int64
+	SetIndex(int64)
+	GetValue() interface{}
+	GetMetadata() *MetadataAsDictionary
+	HasMetadata() bool
+}
+
+func (cev *CompareExchangeValue) getPropertyFromValue(key string) interface{} {
+	if cev.Value == nil {
+		return nil
+	}
+
+	object, isMap := cev.Value.(map[string]interface{})
+	if isMap == false {
+		return nil
+	}
+
+	keyValue, exists := object[key]
+	if exists == false {
+		return nil
+	}
+
+	return keyValue
+}
+
+func (cev *CompareExchangeValue) hasChanged(other *CompareExchangeValue) (bool, error) {
+	if cev == other {
+		return false, nil
+	} // ptr equals
+
+	if strings.EqualFold(cev.GetKey(), other.GetKey()) == false {
+		return false, newIllegalArgumentError("Keys do not match. Expected: " + cev.Key + " but was " + other.Key)
+	}
+
+	if cev.Index != other.Index {
+		return true, nil
+	}
+
+	first, err := jsonMarshal(cev.Value)
+	if err != nil {
+		return false, err
+	}
+	second, err := jsonMarshal(other.Value)
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(first, second) == false, nil //compare
+}
+
+func (cev *CompareExchangeValue) GetKey() string                     { return cev.Key }
+func (cev *CompareExchangeValue) GetIndex() int64                    { return cev.Index }
+func (cev *CompareExchangeValue) SetIndex(index int64)               { cev.Index = index }
+func (cev *CompareExchangeValue) GetValue() interface{}              { return cev.Value }
+func (cev *CompareExchangeValue) GetMetadata() *MetadataAsDictionary { return cev.Metadata }
+func (cev *CompareExchangeValue) HasMetadata() bool                  { return cev.Metadata != nil }
 
 // NewCompareExchangeValue returns new CompareExchangeValue
 func NewCompareExchangeValue(key string, index int64, value interface{}) *CompareExchangeValue {
+	return NewCompareExchangeValueBase(key, index, value, nil, nil)
+}
+
+func NewCompareExchangeValueBase(key string, index int64, value interface{}, changeVector *string, dictionary *MetadataAsDictionary) *CompareExchangeValue {
 	return &CompareExchangeValue{
-		Key:   key,
-		Index: index,
-		Value: value,
+		Key:          key,
+		Index:        index,
+		Value:        value,
+		ChangeVector: changeVector,
+		Metadata:     dictionary,
 	}
 }

--- a/constants.go
+++ b/constants.go
@@ -36,4 +36,10 @@ const (
 	headersClientVersion              = "Raven-Client-Version"
 	headersEtag                       = "ETag"
 	headersIfNoneMatch                = "If-None-Match"
+	lastKnownClusterTransactionIndex  = "Known-Raft-Index"
+
+	TransactionMode_SingleNode  = 0
+	TransactionMode_ClusterWide = 1
 )
+
+type TransactionMode = int

--- a/document_session.go
+++ b/document_session.go
@@ -67,8 +67,12 @@ func (s *DocumentSession) Revisions() *RevisionsSessionOperations {
 
 // NewDocumentSession creates a new DocumentSession
 func NewDocumentSession(dbName string, documentStore *DocumentStore, id string, re *RequestExecutor) *DocumentSession {
+	return newDocumentSessionBase(dbName, documentStore, id, re, TransactionMode_SingleNode, nil)
+}
+
+func newDocumentSessionBase(dbName string, documentStore *DocumentStore, id string, re *RequestExecutor, transactionMode int, disableAtomicDocumentWritesInClusterWideTransaction *bool) *DocumentSession {
 	res := &DocumentSession{
-		InMemoryDocumentSessionOperations: newInMemoryDocumentSessionOperations(dbName, documentStore, re, id),
+		InMemoryDocumentSessionOperations: newInMemoryDocumentSessionOperations(dbName, documentStore, re, id, transactionMode, disableAtomicDocumentWritesInClusterWideTransaction),
 	}
 
 	res.InMemoryDocumentSessionOperations.session = res
@@ -99,7 +103,7 @@ func (s *DocumentSession) SaveChanges() error {
 		return err
 	}
 	result := command.Result
-	return saveChangeOperation.setResult(result.Results)
+	return saveChangeOperation.setResult(result)
 }
 
 // Exists returns true if an entity with a given id exists in the database

--- a/document_session_cluster_transaction.go
+++ b/document_session_cluster_transaction.go
@@ -5,9 +5,9 @@ import (
 )
 
 type ClusterTransactionOperations struct {
-	session                             *InMemoryDocumentSessionOperations
-	state                               map[string]*CompareExchangeSessionValue
-	missingDocumentsTooAtomicGuardIndex map[string]string
+	session                            *InMemoryDocumentSessionOperations
+	state                              map[string]*CompareExchangeSessionValue
+	missingDocumentsToAtomicGuardIndex map[string]string
 }
 
 func (cto *ClusterTransactionOperations) GetNumberOfTrackedCompareExchangeValues() int {
@@ -19,11 +19,11 @@ func (cto *ClusterTransactionOperations) GetNumberOfTrackedCompareExchangeValues
 }
 
 func (cto *ClusterTransactionOperations) TryGetMissingAtomicGuardFor(docId string) (*string, bool) {
-	if cto.missingDocumentsTooAtomicGuardIndex == nil {
+	if cto.missingDocumentsToAtomicGuardIndex == nil {
 		return nil, false
 	}
 
-	value, exists := cto.missingDocumentsTooAtomicGuardIndex[docId]
+	value, exists := cto.missingDocumentsToAtomicGuardIndex[docId]
 	if exists == false {
 		return nil, false
 	}

--- a/document_session_cluster_transaction.go
+++ b/document_session_cluster_transaction.go
@@ -1,0 +1,282 @@
+package ravendb
+
+import (
+	"reflect"
+)
+
+type ClusterTransactionOperations struct {
+	session                             *InMemoryDocumentSessionOperations
+	state                               map[string]*CompareExchangeSessionValue
+	missingDocumentsTooAtomicGuardIndex map[string]string
+}
+
+func (cto *ClusterTransactionOperations) GetNumberOfTrackedCompareExchangeValues() int {
+	if nil == cto.state {
+		return 0
+	}
+
+	return len(cto.state)
+}
+
+func (cto *ClusterTransactionOperations) TryGetMissingAtomicGuardFor(docId string) (*string, bool) {
+	if cto.missingDocumentsTooAtomicGuardIndex == nil {
+		return nil, false
+	}
+
+	value, exists := cto.missingDocumentsTooAtomicGuardIndex[docId]
+	if exists == false {
+		return nil, false
+	}
+
+	return &value, true
+}
+
+func (cto *ClusterTransactionOperations) IsTracked(key string) bool {
+	_, exists := cto.tryGetCompareExchangeValueFromSession(key)
+	return exists
+}
+
+func (cto *ClusterTransactionOperations) tryGetCompareExchangeValueFromSession(key string) (*CompareExchangeSessionValue, bool) {
+	value, exists := cto.state[key]
+	return value, exists
+}
+
+func (cto *ClusterTransactionOperations) updateState(key string, index int64) (*CompareExchangeSessionValue, bool) {
+	value, exists := cto.tryGetCompareExchangeValueFromSession(key)
+
+	if exists == false {
+		return nil, false
+	}
+
+	value.UpdateState(index)
+	return value, true
+}
+
+func (cto *ClusterTransactionOperations) Clear() {
+	cto.state = make(map[string]*CompareExchangeSessionValue)
+}
+
+func (cto *ClusterTransactionOperations) CreateCompareExchangeValue(key string, item interface{}) (interface{}, error) {
+	if len(key) == 0 {
+		return nil, newIllegalArgumentError("Key cannot be null or empty")
+	}
+
+	var exists bool
+	var value *CompareExchangeSessionValue
+	value, exists = cto.tryGetCompareExchangeValueFromSession(key)
+
+	if exists == false {
+		var err error
+		value, err = NewCompareExchangeSessionValue(key, 0, compareExchangeValueStateNone)
+		if err != nil {
+			return nil, err
+		}
+		cto.state[key] = value
+	}
+
+	return value.Create(item)
+}
+
+func (cto *ClusterTransactionOperations) prepareCompareExchangeEntities(result *saveChangesData) error {
+	if len(cto.state) == 0 {
+		return nil
+	}
+
+	for _, value := range cto.state {
+		command, err := value.GetCommand(cto.session)
+		if err != nil {
+			return err
+		}
+		if command == nil {
+			continue
+		}
+
+		result.addSessionCommandData(command)
+	}
+
+	return nil
+}
+
+func (cto *ClusterTransactionOperations) GetCompareExchangeValue(clazz reflect.Type, key string) (*CompareExchangeValue, error) {
+	return cto.getCompareExchangeValueInternal(clazz, key)
+
+}
+
+func (cto *ClusterTransactionOperations) GetCompareExchangeValues(clazz reflect.Type, keys []string) (map[string]*CompareExchangeValue, error) {
+	return cto.getCompareExchangeValuesInternal(clazz, keys)
+
+}
+
+func (cto *ClusterTransactionOperations) getCompareExchangeValuesInternal(clazz reflect.Type, keys []string) (map[string]*CompareExchangeValue, error) {
+	results, notTracked, err := cto.getCompareExchangeValuesFromSessionInternal(clazz, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	if notTracked == nil || len(notTracked) == 0 {
+		return results, nil
+	}
+
+	cto.session.incrementRequestCount()
+
+	operation, err := NewGetCompareExchangeValuesOperationWithKeys(clazz, notTracked)
+	if err != nil {
+		return nil, err
+	}
+	err = cto.session.GetOperations().Send(operation, cto.session.sessionInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	operationResult := operation.Command.Result
+
+	for _, key := range notTracked {
+		value, exists := operationResult[key]
+
+		if exists == false || value == nil {
+			cto.registerMissingCompareExchangeValue(key)
+			results[key] = nil
+			continue
+		}
+
+		sessionValue, err := cto.registerCompareExchangeValue(value)
+		if err != nil {
+			return nil, err
+		}
+		resultValue, err := sessionValue.GetValue(clazz, cto.session)
+		if err != nil {
+			return nil, err
+		}
+
+		results[value.GetKey()] = resultValue
+	}
+
+	return results, nil
+}
+
+func (cto *ClusterTransactionOperations) getCompareExchangeValueInternal(clazz reflect.Type, key string) (*CompareExchangeValue, error) {
+	v, notTracked := cto.getCompareExchangeValueFromSessionInternal(clazz, key)
+	if notTracked == false {
+		return v, nil
+	}
+
+	cto.session.incrementRequestCount()
+
+	operation, err := NewGetCompareExchangeValueOperation(clazz, key)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cto.session.GetOperations().Send(operation, cto.session.sessionInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	value := operation.Command.Result
+	if value == nil {
+		cto.registerMissingCompareExchangeValue(key)
+		return nil, nil
+	}
+
+	sessionValue, err := cto.registerCompareExchangeValue(value)
+
+	if err == nil && sessionValue != nil {
+		return sessionValue.GetValue(clazz, cto.session)
+	}
+
+	return nil, err
+}
+
+func (cto *ClusterTransactionOperations) registerCompareExchangeValue(value *CompareExchangeValue) (*CompareExchangeSessionValue, error) {
+	if cto.session.noTracking {
+		return NewCompareExchangeSessionValue2(value)
+	}
+
+	var err error
+	sesionValue, exists := cto.state[value.GetKey()]
+
+	if exists == false || sesionValue == nil {
+		sesionValue, err = NewCompareExchangeSessionValue2(value)
+		if err != nil {
+			return nil, err
+		}
+		cto.state[value.GetKey()] = sesionValue
+		return sesionValue, nil
+	}
+
+	err = sesionValue.UpdateValue(value)
+
+	return sesionValue, err
+}
+
+func (cto *ClusterTransactionOperations) registerMissingCompareExchangeValue(key string) (*CompareExchangeSessionValue, error) {
+	value, err := NewCompareExchangeSessionValue(key, -1, exchangeValueStateMissing)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if cto.session.noTracking {
+		return value, nil
+	}
+
+	cto.state[key] = value
+	return value, nil
+}
+
+func (cto *ClusterTransactionOperations) getCompareExchangeValueFromSessionInternal(clazz reflect.Type, key string) (compareExchangeValue *CompareExchangeValue, notTracked bool) {
+	result, exist := cto.tryGetCompareExchangeValueFromSession(key)
+
+	if exist == false {
+		return nil, true
+	}
+
+	//we've already deserialized, maybe except situation when user wants get deriative type?
+
+	return result.value, false
+}
+
+func (cto *ClusterTransactionOperations) getCompareExchangeValuesFromSessionInternal(clazz reflect.Type, keys []string) (map[string]*CompareExchangeValue, []string, error) {
+	var results map[string]*CompareExchangeValue
+	results = make(map[string]*CompareExchangeValue)
+	var notTracked []string
+
+	if keys == nil || len(keys) == 0 {
+		return results, nil, nil
+	}
+
+	for _, key := range keys {
+		cev, exists := cto.tryGetCompareExchangeValueFromSession(key)
+
+		if exists {
+			val, err := cev.GetValue(clazz, cto.session)
+			if err != nil {
+				return results, nil, err
+			}
+			results[key] = val
+			continue
+		}
+
+		notTracked = append(notTracked, key)
+	}
+
+	return results, notTracked, nil
+}
+
+//func newDocumentSessionClusterTransactions(session *InMemoryDocumentSessionOperations) *DocumentSessionTransactionOperations {
+//	return &DocumentSessionTransactionOperations{
+//		AdvancedSessionExtensionBase: newAdvancedSessionExtensionBase(session),
+//	}
+//}
+//
+//func (to *DocumentSessionTransactionOperations) DeleteCompareExchangeValue(key string, index int64) {
+//
+//}
+
+//void DeleteCompareExchangeValue(string key, long index);
+
+//void DeleteCompareExchangeValue<T>(CompareExchangeValue<T> item);
+
+//CompareExchangeValue<T> CreateCompareExchangeValue<T>(string key, T value);
+
+// Has to implement ICompareExchangeValue

--- a/document_session_cluster_transaction.go
+++ b/document_session_cluster_transaction.go
@@ -223,14 +223,14 @@ func (cto *ClusterTransactionOperations) getCompareExchangeValueInternal(clazz r
 
 func (cto *ClusterTransactionOperations) registerCompareExchangeValue(value *CompareExchangeValue) (*CompareExchangeSessionValue, error) {
 	if cto.session.noTracking {
-		return NewCompareExchangeSessionValue2(value)
+		return NewCompareExchangeSessionValueWithValue(value)
 	}
 
 	var err error
 	sesionValue, exists := cto.state[value.GetKey()]
 
 	if exists == false || sesionValue == nil {
-		sesionValue, err = NewCompareExchangeSessionValue2(value)
+		sesionValue, err = NewCompareExchangeSessionValueWithValue(value)
 		if err != nil {
 			return nil, err
 		}

--- a/document_session_cluster_transaction.go
+++ b/document_session_cluster_transaction.go
@@ -5,9 +5,8 @@ import (
 )
 
 type ClusterTransactionOperations struct {
-	session                            *InMemoryDocumentSessionOperations
-	state                              map[string]*CompareExchangeSessionValue
-	missingDocumentsToAtomicGuardIndex map[string]string
+	session *InMemoryDocumentSessionOperations
+	state   map[string]*CompareExchangeSessionValue
 }
 
 func (cto *ClusterTransactionOperations) GetNumberOfTrackedCompareExchangeValues() int {
@@ -16,19 +15,6 @@ func (cto *ClusterTransactionOperations) GetNumberOfTrackedCompareExchangeValues
 	}
 
 	return len(cto.state)
-}
-
-func (cto *ClusterTransactionOperations) TryGetMissingAtomicGuardFor(docId string) (*string, bool) {
-	if cto.missingDocumentsToAtomicGuardIndex == nil {
-		return nil, false
-	}
-
-	value, exists := cto.missingDocumentsToAtomicGuardIndex[docId]
-	if exists == false {
-		return nil, false
-	}
-
-	return &value, true
 }
 
 func (cto *ClusterTransactionOperations) IsTracked(key string) bool {

--- a/document_store.go
+++ b/document_store.go
@@ -330,7 +330,16 @@ func (s *DocumentStore) OpenSessionWithOptions(options *SessionOptions) (*Docume
 	if requestExecutor == nil {
 		requestExecutor = s.GetRequestExecutor(databaseName)
 	}
-	session := NewDocumentSession(databaseName, s, sessionID, requestExecutor)
+
+	transactionMode := options.TransactionMode
+	err := assertTransactionMode(transactionMode)
+	if err != nil {
+		return nil, err
+	}
+
+	disableAtomicDocumentWritesInClusterWideTransaction := options.DisableAtomicDocumentWritesInClusterWideTransaction
+
+	session := newDocumentSessionBase(databaseName, s, sessionID, requestExecutor, transactionMode, disableAtomicDocumentWritesInClusterWideTransaction)
 	s.registerEvents(session.InMemoryDocumentSessionOperations)
 	s.afterSessionCreated(session.InMemoryDocumentSessionOperations)
 	return session, nil

--- a/entity_to_json.go
+++ b/entity_to_json.go
@@ -26,6 +26,10 @@ func (e *entityToJSON) getMissingDictionary() map[interface{}]map[string]interfa
 }
 
 func convertEntityToJSON(entity interface{}, documentInfo *documentInfo) map[string]interface{} {
+	return convertEntityToJSONRaw(entity, documentInfo, true)
+}
+
+func convertEntityToJSONRaw(entity interface{}, documentInfo *documentInfo, removeIdentityProperty bool) map[string]interface{} {
 	// maybe we don't need to do anything?
 	if v, ok := entity.(map[string]interface{}); ok {
 		return v
@@ -34,7 +38,9 @@ func convertEntityToJSON(entity interface{}, documentInfo *documentInfo) map[str
 
 	entityToJSONWriteMetadata(jsonNode, documentInfo)
 
-	tryRemoveIdentityProperty(jsonNode)
+	if removeIdentityProperty {
+		tryRemoveIdentityProperty(jsonNode)
+	}
 
 	return jsonNode
 }
@@ -179,6 +185,22 @@ func entityToJSONWriteMetadata(jsonNode map[string]interface{}, documentInfo *do
 	if setMetadata {
 		jsonNode[MetadataKey] = metadataNode
 	}
+}
+
+func metadataToObjectNode(metadata map[string]interface{}, metadataInstance *MetadataAsDictionary) map[string]interface{} {
+	var metadataNode map[string]interface{}
+	if len(metadata) > 0 {
+		for property, v := range metadata {
+			v = deepCopy(v)
+			metadataNode[property] = v
+		}
+	} else if metadataInstance != nil {
+		for key, value := range metadataInstance.EntrySet() {
+			metadataNode[key] = value
+		}
+	}
+
+	return metadataNode
 }
 
 /*

--- a/in_memory_document_session_operations.go
+++ b/in_memory_document_session_operations.go
@@ -1431,3 +1431,8 @@ func (s *InMemoryDocumentSessionOperations) GetClusterSession() (*ClusterTransac
 
 	return s.clusterTransactions, nil
 }
+
+// Track entities in session. Default: false
+func (s *InMemoryDocumentSessionOperations) NoTracking(mode bool) {
+	s.noTracking = mode
+}

--- a/json_array_result.go
+++ b/json_array_result.go
@@ -2,7 +2,8 @@ package ravendb
 
 // JSONArrayResult describes server's JSON response to batch command
 type JSONArrayResult struct {
-	Results []map[string]interface{} `json:"Results"`
+	Results          []map[string]interface{} `json:"Results"`
+	TransactionIndex int64                    `json:"TransactionIndex"`
 }
 
 func (r *JSONArrayResult) getResults() []map[string]interface{} {

--- a/raft_id_generator.go
+++ b/raft_id_generator.go
@@ -14,6 +14,15 @@ type RaftCommandBase struct {
 	raftUniqueRequestId string
 }
 
+func RaftId() (string, error) {
+	newUUID, err := uuid.NewUUID()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", newUUID), nil
+}
+
 func (cmd *RaftCommandBase) RaftUniqueRequestId() (string, error) {
 	if cmd.raftUniqueRequestId == "" {
 		newUUID, err := uuid.NewUUID()

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Linux build Status](https://travis-ci.org/ravendb/ravendb-go-client.svg?branch=master)](https://travis-ci.org/ravendb/ravendb-go-client) [![Windows build status](https://ci.appveyor.com/api/projects/status/rf326yoxl1uf444h/branch/master?svg=true)](https://ci.appveyor.com/project/ravendb/ravendb-go-client/branch/master)
+[![compile](https://github.com/ravendb/ravendb-go-client/actions/workflows/RavenClient.yml/badge.svg)](https://github.com/ravendb/ravendb-go-client/actions/workflows/RavenClient.yml)
 
 This is information on how to use the library. For docs on working on the library itself see [readme-dev.md](readme-dev.md).
 

--- a/readme.md
+++ b/readme.md
@@ -953,7 +953,7 @@ See `subscriptions()` in [examples/main.go](examples/main.go) for full example.
 
 # Cluster wide transactions
 
-## Setup a session
+### Setup a session
 To set session transaction as cluster wide you've to set `TransactionMode` in `SessionOptions`
 as `TransactionMode_ClusterWide`
 
@@ -964,3 +964,67 @@ ravendb.SessionOptions{
 }
 ```
 
+## Cluster transactions
+
+In order to create cluster transactions you have to get
+cluster transaction object from your session:
+
+```go
+clusterTransaction, err := session.Advanced().ClusterTransaction()
+```
+
+Assert error to make sure your session configuration is correct.
+
+
+### Inserting new CompareExchangeValue
+
+```go
+var objectToInsert interface{}
+var id             string
+value, error := clusterTransaction.CreateCompareExchangeValue(key, objectToInsert)
+```
+
+### Getting existing CompareExchangeValue from server
+You can retrieve your value using various methods.
+
+#### - Get value by key
+```go
+var dataType reflect.Type // identifies your data-struct type
+var key string
+value, error := clusterTransaction.GetCompareExchangeValue(dataType, key)
+```
+
+#### - Get values by keys
+```go
+var dataType reflect.Type // identifies your data-struct type
+var keys []string
+value, error := clusterTransaction.GetCompareExchangeValuesWithKeys(dataType, keys)
+```
+
+Retruns map where keys are identifiers.
+
+#### Get values whose IDs start with a string
+```go
+var dataType reflect.Type // identifies your data-struct type
+var startsWith string
+var start int
+var pageSize int
+value, error := clusterTransaction.GetCompareExchangeValues(dataType, startsWith, start, pageSize)
+```
+
+Retruns map where keys are identifiers.
+
+### Delete CompareExchangeValue
+
+#### By field key and index
+```go
+var key string
+var index int64
+err := clusterTransaction.DeleteCompareExchangeValueByKey(key, index)
+```
+
+#### By CompareExchangeValue object
+```go
+var compareExchangeValue *ravendb.CompareExchangeValue
+err := clusterTransaction.DeleteCompareExchangeValue(compareExchangeValue)
+```

--- a/readme.md
+++ b/readme.md
@@ -950,3 +950,17 @@ case <-time.After(time.Second * 5):
 _ = worker.Close()
 ```
 See `subscriptions()` in [examples/main.go](examples/main.go) for full example.
+
+# Cluster wide transactions
+
+## Setup a session
+To set session transaction as cluster wide you've to set `TransactionMode` in `SessionOptions`
+as `TransactionMode_ClusterWide`
+
+```go
+ravendb.SessionOptions{
+                        [...]
+			TransactionMode: ravendb.TransactionMode_ClusterWide,
+}
+```
+

--- a/session_info.go
+++ b/session_info.go
@@ -2,5 +2,6 @@ package ravendb
 
 // SessionInfo describes a session
 type SessionInfo struct {
-	SessionID int
+	SessionID                   int
+	lastClusterTransactionIndex *int64
 }

--- a/session_options.go
+++ b/session_options.go
@@ -2,6 +2,16 @@ package ravendb
 
 // SessionOptions describes session options
 type SessionOptions struct {
-	Database        string
-	RequestExecutor *RequestExecutor
+	Database                                            string
+	RequestExecutor                                     *RequestExecutor
+	TransactionMode                                     int
+	DisableAtomicDocumentWritesInClusterWideTransaction *bool
+}
+
+func assertTransactionMode(transactionMode int) error {
+	if transactionMode == TransactionMode_SingleNode || transactionMode == TransactionMode_ClusterWide {
+		return nil
+	}
+
+	return newIllegalStateError("transactionMode has to be set as `TransactionMode_SingleNode` or 'TransactionMode_ClusterWide`.")
 }

--- a/tests/cluster_transaction_test.go
+++ b/tests/cluster_transaction_test.go
@@ -1,0 +1,144 @@
+package tests
+
+import (
+	"github.com/ravendb/ravendb-go-client"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func throwOnInvalidTransactionMode(t *testing.T, driver *RavenTestDriver) {
+	store := driver.getDocumentStoreMust(t)
+	user := &User{}
+	user.setName("Karmel")
+
+	var session *ravendb.DocumentSession
+	{
+		session = openSessionMust(t, store)
+
+		_, err := session.Advanced().ClusterTransaction()
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "This function is part of cluster transaction session, in order to use it you have to open the Session with ClusterWide option."))
+
+		session.Close()
+		session = nil
+	}
+
+	disableAtomicDocumentWritesInClusterWideTransaction := true
+	{
+		session = openSessionMustWithOptions(t, store, &ravendb.SessionOptions{
+			Database:        "",
+			RequestExecutor: nil,
+			TransactionMode: ravendb.TransactionMode_ClusterWide,
+			DisableAtomicDocumentWritesInClusterWideTransaction: &disableAtomicDocumentWritesInClusterWideTransaction,
+		})
+
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user)
+		session.Advanced().SetTransactionMode(ravendb.TransactionMode_SingleNode)
+
+		err = session.SaveChanges()
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "Performing cluster transaction operation require the TransactionMode to be set to TransactionMode_ClusterWide"))
+
+		session.Advanced().SetTransactionMode(ravendb.TransactionMode_ClusterWide)
+
+		err = session.SaveChanges()
+		assert.NoError(t, err)
+		session.Close()
+	}
+}
+
+func testSessionSequance(t *testing.T, driver *RavenTestDriver) {
+	store := driver.getDocumentStoreMust(t)
+	user1 := &User{}
+	user2 := &User{}
+
+	user1.setName("Karmel")
+	user2.setName("Indych")
+	dat := true
+	{
+		session := openSessionMustWithOptions(t, store, &ravendb.SessionOptions{
+			Database:        "",
+			RequestExecutor: nil,
+			TransactionMode: ravendb.TransactionMode_ClusterWide,
+			DisableAtomicDocumentWritesInClusterWideTransaction: &dat,
+		})
+
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1)
+		err = session.StoreWithID(user1, "users/1")
+		assert.NoError(t, err)
+
+		err = session.SaveChanges()
+		assert.NoError(t, err)
+
+		value, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
+		value.Value = user2
+
+		session.StoreWithID(user2, "users/2")
+		user1.setAge(10)
+		session.StoreWithID(user1, "users/1")
+		err = session.SaveChanges()
+		assert.NoError(t, err)
+		session.Close()
+	}
+}
+
+func canCreateClusterTransactionRequest(t *testing.T, driver *RavenTestDriver) {
+	store := driver.getDocumentStoreMust(t)
+	user1 := &User{}
+	user3 := &User{}
+
+	user1.setName("Karmel")
+	user3.setName("Indych")
+	dat := true
+	{
+		session := openSessionMustWithOptions(t, store, &ravendb.SessionOptions{
+			Database:        "",
+			RequestExecutor: nil,
+			TransactionMode: ravendb.TransactionMode_ClusterWide,
+			DisableAtomicDocumentWritesInClusterWideTransaction: &dat,
+		})
+
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		_, err = clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1)
+		assert.NoError(t, err)
+
+		err = session.StoreWithID(user3, "foo/bar")
+		assert.NoError(t, err)
+
+		err = session.SaveChanges()
+		assert.NoError(t, err)
+
+		cev, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
+		assert.NoError(t, err)
+
+		userFromCEV, ok := cev.Value.(*User)
+		assert.True(t, ok)
+
+		user := &User{}
+		err = session.Load(&user, "foo/bar")
+		assert.NoError(t, err)
+
+		assert.Equal(t, user1.Name, userFromCEV.Name)
+		assert.Equal(t, user.Name, user3.Name)
+		session.Close()
+	}
+}
+
+func TestClusterTransaction(t *testing.T) {
+	driver := createTestDriver(t)
+	destroy := func() { destroyDriver(t, driver) }
+	defer recoverTest(t, destroy)
+	throwOnInvalidTransactionMode(t, driver)
+	testSessionSequance(t, driver)
+	canCreateClusterTransactionRequest(t, driver)
+}

--- a/tests/cluster_transaction_test.go
+++ b/tests/cluster_transaction_test.go
@@ -19,9 +19,8 @@ func throwOnInvalidTransactionMode(t *testing.T, driver *RavenTestDriver) {
 	{
 		session = openSessionMust(t, store)
 
-		_, err := session.Advanced().ClusterTransaction()
-		assert.Error(t, err)
-		assert.True(t, strings.Contains(err.Error(), "This function is part of cluster transaction session, in order to use it you have to open the Session with ClusterWide option."))
+		ct := session.Advanced().ClusterTransaction()
+		assert.Nil(t, ct)
 
 		session.Close()
 		session = nil
@@ -36,13 +35,13 @@ func throwOnInvalidTransactionMode(t *testing.T, driver *RavenTestDriver) {
 			DisableAtomicDocumentWritesInClusterWideTransaction: &disableAtomicDocumentWritesInClusterWideTransaction,
 		})
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
+		clusterTransaction := session.Advanced().ClusterTransaction()
+		assert.NotNil(t, clusterTransaction)
 
-		clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user)
+		session.Advanced().ClusterTransaction().CreateCompareExchangeValue("usernames/ayende", user)
 		session.Advanced().SetTransactionMode(ravendb.TransactionMode_SingleNode)
 
-		err = session.SaveChanges()
+		err := session.SaveChanges()
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "Performing cluster transaction operation require the TransactionMode to be set to TransactionMode_ClusterWide"))
 
@@ -72,17 +71,15 @@ func testSessionSequance(t *testing.T, driver *RavenTestDriver) {
 			DisableAtomicDocumentWritesInClusterWideTransaction: &dat,
 		})
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
-
-		clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1)
+		var err error
+		session.Advanced().ClusterTransaction().CreateCompareExchangeValue("usernames/ayende", user1)
 		err = session.StoreWithID(user1, "users/1")
 		assert.NoError(t, err)
 
 		err = session.SaveChanges()
 		assert.NoError(t, err)
 
-		value, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
+		value, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
 		value.Value = user2
 
 		session.StoreWithID(user2, "users/2")
@@ -109,23 +106,21 @@ func testSessionOnPrimitiveType(t *testing.T, driver *RavenTestDriver) {
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		var err error
+		_, err = session.Advanced().ClusterTransaction().CreateCompareExchangeValue("int/Key", 1)
 		assert.NoError(t, err)
 
-		_, err = clusterTransaction.CreateCompareExchangeValue("int/Key", 1)
-		assert.NoError(t, err)
-
-		_, err = clusterTransaction.CreateCompareExchangeValue("string/Key", "hello")
+		_, err = session.Advanced().ClusterTransaction().CreateCompareExchangeValue("string/Key", "hello")
 		assert.NoError(t, err)
 
 		err = session.SaveChanges()
 		assert.NoError(t, err)
 
-		value, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
+		value, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, 1, value.Value)
 
-		value, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
+		value, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, "hello", value.Value)
 	}
@@ -134,24 +129,21 @@ func testSessionOnPrimitiveType(t *testing.T, driver *RavenTestDriver) {
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
-
-		value, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
+		value, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, 1, value.Value)
 		value.Value = 2
 
-		value, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
+		value, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, 2, value.Value)
 
-		value, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
+		value, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, "hello", value.Value)
 		value.Value = "world"
 
-		value, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
+		value, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, "world", value.Value)
 
@@ -163,14 +155,11 @@ func testSessionOnPrimitiveType(t *testing.T, driver *RavenTestDriver) {
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
-
-		value, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
+		value, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, 2, value.Value)
 
-		value, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
+		value, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
 		assert.NoError(t, err)
 		assert.Equal(t, "world", value.Value)
 	}
@@ -179,16 +168,13 @@ func testSessionOnPrimitiveType(t *testing.T, driver *RavenTestDriver) {
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		value, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
 		assert.NoError(t, err)
+		err = session.Advanced().ClusterTransaction().DeleteCompareExchangeValueByKey("int/Key", value.GetIndex())
 
-		value, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
+		value, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
 		assert.NoError(t, err)
-		err = clusterTransaction.DeleteCompareExchangeValueByKey("int/Key", value.GetIndex())
-
-		value, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
-		assert.NoError(t, err)
-		err = clusterTransaction.DeleteCompareExchangeValue(value)
+		err = session.Advanced().ClusterTransaction().DeleteCompareExchangeValue(value)
 		assert.NoError(t, err)
 
 		err = session.SaveChanges()
@@ -199,13 +185,11 @@ func testSessionOnPrimitiveType(t *testing.T, driver *RavenTestDriver) {
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
-		value, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
+		value, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(int(0)), "int/Key")
 		assert.NoError(t, err)
 		assert.Nil(t, value)
 
-		value, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
+		value, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(string("")), "string/Key")
 		assert.NoError(t, err)
 		assert.Nil(t, value)
 	}
@@ -229,10 +213,8 @@ func canCreateClusterTransactionRequest(t *testing.T, driver *RavenTestDriver) {
 			DisableAtomicDocumentWritesInClusterWideTransaction: &dat,
 		})
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
-
-		_, err = clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1)
+		var err error
+		_, err = session.Advanced().ClusterTransaction().CreateCompareExchangeValue("usernames/ayende", user1)
 		assert.NoError(t, err)
 
 		err = session.StoreWithID(user3, "foo/bar")
@@ -241,7 +223,7 @@ func canCreateClusterTransactionRequest(t *testing.T, driver *RavenTestDriver) {
 		err = session.SaveChanges()
 		assert.NoError(t, err)
 
-		cev, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
+		cev, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
 		assert.NoError(t, err)
 
 		userFromCEV, ok := cev.Value.(*User)
@@ -278,30 +260,26 @@ func canDeleteCompareExchangeValue(t *testing.T, driver *RavenTestDriver) {
 	{
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
-		ct, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
-		ct.CreateCompareExchangeValue("usernames/ayende", user1)
-		ct.CreateCompareExchangeValue("usernames/marcin", user3)
+		session.Advanced().ClusterTransaction().CreateCompareExchangeValue("usernames/ayende", user1)
+		session.Advanced().ClusterTransaction().CreateCompareExchangeValue("usernames/marcin", user3)
 		session.SaveChanges()
 	}
 
 	{
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
-		ct, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
 
-		compareExchangeValue, err := ct.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
+		compareExchangeValue, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
 		assert.NoError(t, err)
 		assert.NotNil(t, compareExchangeValue)
 
-		err = ct.DeleteCompareExchangeValue(compareExchangeValue)
+		err = session.Advanced().ClusterTransaction().DeleteCompareExchangeValue(compareExchangeValue)
 		assert.NoError(t, err)
 
-		compareExchangeValue2, err := ct.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/marcin")
+		compareExchangeValue2, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/marcin")
 		assert.NoError(t, err)
 		assert.NotNil(t, compareExchangeValue2)
-		err = ct.DeleteCompareExchangeValueByKey(compareExchangeValue2.GetKey(), compareExchangeValue2.GetIndex())
+		err = session.Advanced().ClusterTransaction().DeleteCompareExchangeValueByKey(compareExchangeValue2.GetKey(), compareExchangeValue2.GetIndex())
 		assert.NoError(t, err)
 		session.SaveChanges()
 	}
@@ -309,14 +287,12 @@ func canDeleteCompareExchangeValue(t *testing.T, driver *RavenTestDriver) {
 	{
 		session := openSessionMustWithOptions(t, store, options)
 		defer session.Close()
-		ct, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
 
-		compareExchangeValue, err := ct.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
+		compareExchangeValue, err := session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/ayende")
 		assert.NoError(t, err)
 		assert.Nil(t, compareExchangeValue)
 
-		compareExchangeValue, err = ct.GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/marcin")
+		compareExchangeValue, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(&User{}), "usernames/marcin")
 		assert.NoError(t, err)
 		assert.Nil(t, compareExchangeValue)
 	}

--- a/tests/raven_test_driver_test.go
+++ b/tests/raven_test_driver_test.go
@@ -51,7 +51,7 @@ var (
 	// can be changed via SHUFFLE_CLUSTER_NODES=true env variable
 	shuffleClusterNodes = false
 
-	ravendbWindowsDownloadURL = "https://hibernatingrhinos.com/downloads/RavenDB%20for%20Windows%20x64/53000" // for local usage
+	ravendbWindowsDownloadURL = "https://hibernatingrhinos.com/downloads/RavenDB%20for%20Windows%20x64/54000" // for local usage
 
 	ravenWindowsZipPath = "ravendb-latest.zip"
 )
@@ -664,6 +664,13 @@ func shutdownTests() {
 
 func openSessionMust(t *testing.T, store *ravendb.DocumentStore) *ravendb.DocumentSession {
 	session, err := store.OpenSession("")
+	assert.NoError(t, err)
+	assert.NotNil(t, session)
+	return session
+}
+
+func openSessionMustWithOptions(t *testing.T, store *ravendb.DocumentStore, options *ravendb.SessionOptions) *ravendb.DocumentSession {
+	session, err := store.OpenSessionWithOptions(options)
 	assert.NoError(t, err)
 	assert.NotNil(t, session)
 	return session

--- a/tests/ravendb_10641_test.go
+++ b/tests/ravendb_10641_test.go
@@ -112,7 +112,8 @@ func ravendb10641canEditObjectsInMetadata(t *testing.T, driver *RavenTestDriver)
 }
 
 type Document struct {
-	ID string
+	ID   string `json:"ID"`
+	Name string `json:"Name"`
 }
 
 func TestRavenDB10641(t *testing.T) {

--- a/tests/ravendb_12132_test.go
+++ b/tests/ravendb_12132_test.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"github.com/ravendb/ravendb-go-client"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func canCreateClusterTransactionRequest1(t *testing.T, driver *RavenTestDriver) {
+	store := driver.getDocumentStoreMust(t)
+	ravendb.WithFiddler()
+	{
+		session := openSessionMustWithOptions(t, store, &ravendb.SessionOptions{
+			Database:        "",
+			RequestExecutor: nil,
+			TransactionMode: ravendb.TransactionMode_ClusterWide,
+			DisableAtomicDocumentWritesInClusterWideTransaction: nil,
+		})
+
+		user := &Document{ID: "this/is/my/id", Name: "Grisha"}
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		_, err = clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user)
+
+		assert.NoError(t, err)
+
+		err = session.SaveChanges()
+		assert.NoError(t, err)
+
+		var result *ravendb.CompareExchangeValue
+		clusterTransaction, err = session.Advanced().ClusterTransaction()
+
+		result, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Document{}), "usernames/ayende")
+		userFromCluster, cast := result.GetValue().(*Document)
+		assert.True(t, cast)
+		assert.NoError(t, err)
+		assert.Equal(t, user.Name, userFromCluster.Name)
+		assert.Equal(t, user.ID, userFromCluster.ID)
+
+		session.Close()
+	}
+
+	{
+		operation, err := ravendb.NewGetCompareExchangeValueOperation(reflect.TypeOf(&Document{}), "usernames/ayende")
+		assert.NoError(t, err)
+
+		err = store.Operations().Send(operation, nil)
+		assert.NoError(t, err)
+
+		result := operation.Command.Result
+
+		assert.NotNil(t, result)
+
+		docFromServer := result.Value.(*Document)
+		assert.Equal(t, "Grisha", docFromServer.Name)
+		assert.Equal(t, "this/is/my/id", docFromServer.ID)
+	}
+
+	store.Close()
+}
+
+func TestRavenDB12132(t *testing.T) {
+	driver := createTestDriver(t)
+	destroy := func() { destroyDriver(t, driver) }
+	defer recoverTest(t, destroy)
+
+	// matches the order of Java tests
+	canCreateClusterTransactionRequest1(t, driver)
+}

--- a/tests/ravendb_12132_test.go
+++ b/tests/ravendb_12132_test.go
@@ -9,7 +9,6 @@ import (
 
 func canCreateClusterTransactionRequest1(t *testing.T, driver *RavenTestDriver) {
 	store := driver.getDocumentStoreMust(t)
-	ravendb.WithFiddler()
 	{
 		session := openSessionMustWithOptions(t, store, &ravendb.SessionOptions{
 			Database:        "",

--- a/tests/ravendb_12132_test.go
+++ b/tests/ravendb_12132_test.go
@@ -17,11 +17,10 @@ func canCreateClusterTransactionRequest1(t *testing.T, driver *RavenTestDriver) 
 			DisableAtomicDocumentWritesInClusterWideTransaction: nil,
 		})
 
+		var err error
 		user := &Document{ID: "this/is/my/id", Name: "Grisha"}
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
-
-		_, err = clusterTransaction.CreateCompareExchangeValue("usernames/ayende", user)
+		assert.NotNil(t, session.Advanced().ClusterTransaction())
+		_, err = session.Advanced().ClusterTransaction().CreateCompareExchangeValue("usernames/ayende", user)
 
 		assert.NoError(t, err)
 
@@ -29,9 +28,8 @@ func canCreateClusterTransactionRequest1(t *testing.T, driver *RavenTestDriver) 
 		assert.NoError(t, err)
 
 		var result *ravendb.CompareExchangeValue
-		clusterTransaction, err = session.Advanced().ClusterTransaction()
 
-		result, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Document{}), "usernames/ayende")
+		result, err = session.Advanced().ClusterTransaction().GetCompareExchangeValue(reflect.TypeOf(&Document{}), "usernames/ayende")
 		userFromCluster, cast := result.GetValue().(*Document)
 		assert.True(t, cast)
 		assert.NoError(t, err)

--- a/tests/ravendb_14006_test.go
+++ b/tests/ravendb_14006_test.go
@@ -15,8 +15,6 @@ type Company2 struct {
 }
 
 func compareExchangeValueTrackingInSession(t *testing.T, driver *RavenTestDriver) {
-	//ravendb.WithFiddler()
-
 	store := driver.getDocumentStoreMust(t)
 	options := &ravendb.SessionOptions{
 		Database:        "",
@@ -48,12 +46,13 @@ func compareExchangeValueTrackingInSession(t *testing.T, driver *RavenTestDriver
 		assert.Equal(t, address, value1.GetValue())
 		assert.Equal(t, company.ExternalId, value1.GetKey())
 		assert.Equal(t, int64(0), value1.GetIndex())
-
 		err = session.SaveChanges()
 		assert.NoError(t, err)
 
 		assert.Equal(t, numberOfRequest+1, session.Advanced().GetNumberOfRequests())
 
+		value1, err = clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Address{}), company.ExternalId)
+		assert.NoError(t, err)
 		assert.Equal(t, address, value1.GetValue())
 		assert.Equal(t, company.ExternalId, value1.GetKey())
 		assert.True(t, value1.GetIndex() > int64(0))
@@ -102,13 +101,13 @@ func compareExchangeValueTrackingInSession(t *testing.T, driver *RavenTestDriver
 		assert.NoError(t, err)
 		assert.Equal(t, numberOfRequest+2, session.Advanced().GetNumberOfRequests())
 
-		values, err := ct.GetCompareExchangeValues(reflect.TypeOf(&Address{}), []string{"companies/cf", "companies/hr"})
+		values, err := ct.GetCompareExchangeValuesWithKeys(reflect.TypeOf(&Address{}), []string{"companies/cf", "companies/hr"})
 		assert.Equal(t, numberOfRequest+2, session.Advanced().GetNumberOfRequests())
 		assert.Equal(t, 2, len(values))
 		assert.Equal(t, value1, values[value1.GetKey()])
 		assert.Equal(t, value2, values[value2.GetKey()])
 
-		values, err = ct.GetCompareExchangeValues(reflect.TypeOf(&Address{}), []string{"companies/cf", "companies/hr", "companies/hx"})
+		values, err = ct.GetCompareExchangeValuesWithKeys(reflect.TypeOf(&Address{}), []string{"companies/cf", "companies/hr", "companies/hx"})
 		assert.Equal(t, 3, len(values))
 		assert.Equal(t, numberOfRequest+3, session.Advanced().GetNumberOfRequests())
 		assert.Equal(t, value1, values[value1.GetKey()])
@@ -121,6 +120,8 @@ func compareExchangeValueTrackingInSession(t *testing.T, driver *RavenTestDriver
 		assert.Nil(t, value3)
 		assert.Nil(t, values["companies/hx"])
 		err = session.SaveChanges()
+		assert.Equal(t, numberOfRequest+3, session.Advanced().GetNumberOfRequests())
+
 		assert.NoError(t, err)
 
 		address := &Address{City: "Bydgoszcz"}
@@ -133,10 +134,132 @@ func compareExchangeValueTrackingInSession(t *testing.T, driver *RavenTestDriver
 	}
 }
 
+func compareExchangeValueTrackingInSession_NoTracking(t *testing.T, driver *RavenTestDriver) {
+	store := driver.getDocumentStoreMust(t)
+	options := &ravendb.SessionOptions{
+		Database:        "",
+		RequestExecutor: nil,
+		TransactionMode: ravendb.TransactionMode_ClusterWide,
+	}
+	company := &Company2{Id: "companies/1", ExternalId: "companies/cf", Name: "CF"}
+
+	{
+		session := openSessionMustWithOptions(t, store, options)
+		session.NoTracking(true)
+
+		session.Store(company)
+
+		address := &Address{City: "Torun"}
+
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		clusterTransaction.CreateCompareExchangeValue(company.ExternalId, address)
+		session.SaveChanges()
+		session.Close()
+	}
+
+	{
+		session := openSessionMustWithOptions(t, store, options)
+		session.NoTracking(true)
+		defer session.Close()
+
+		numberOfRequests := session.Advanced().GetNumberOfRequests()
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		value1, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Address{}), company.ExternalId)
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+1, session.Advanced().GetNumberOfRequests())
+
+		value2, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Address{}), company.ExternalId)
+		assert.NoError(t, err)
+
+		assert.Equal(t, numberOfRequests+2, session.Advanced().GetNumberOfRequests())
+		assert.True(t, value1 != value2)
+
+		value3, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Address{}), company.ExternalId)
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+3, session.Advanced().GetNumberOfRequests())
+		assert.True(t, value2 != value3)
+	}
+
+	{
+		session := openSessionMustWithOptions(t, store, options)
+		session.NoTracking(true)
+		defer session.Close()
+
+		numberOfRequests := session.Advanced().GetNumberOfRequests()
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		value1, err := clusterTransaction.GetCompareExchangeValues(reflect.TypeOf(&Address{}), company.ExternalId, 0, 25)
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+1, session.Advanced().GetNumberOfRequests())
+
+		value2, err := clusterTransaction.GetCompareExchangeValues(reflect.TypeOf(&Address{}), company.ExternalId, 0, 25)
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+2, session.Advanced().GetNumberOfRequests())
+
+		assert.False(t, mapEquals(value1, value2))
+
+		value3, err := clusterTransaction.GetCompareExchangeValues(reflect.TypeOf(&Address{}), company.ExternalId, 0, 25)
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+3, session.Advanced().GetNumberOfRequests())
+		assert.False(t, mapEquals(value3, value2))
+	}
+
+	{
+		session := openSessionMustWithOptions(t, store, options)
+		session.NoTracking(true)
+		defer session.Close()
+
+		numberOfRequests := session.Advanced().GetNumberOfRequests()
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		value1, err := clusterTransaction.GetCompareExchangeValuesWithKeys(reflect.TypeOf(&Address{}), []string{company.ExternalId})
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+1, session.Advanced().GetNumberOfRequests())
+
+		value2, err := clusterTransaction.GetCompareExchangeValuesWithKeys(reflect.TypeOf(&Address{}), []string{company.ExternalId})
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+2, session.Advanced().GetNumberOfRequests())
+
+		assert.False(t, mapEquals(value1, value2))
+
+		value3, err := clusterTransaction.GetCompareExchangeValuesWithKeys(reflect.TypeOf(&Address{}), []string{company.ExternalId})
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequests+3, session.Advanced().GetNumberOfRequests())
+		assert.False(t, mapEquals(value2, value3))
+	}
+}
+
+// Compare values by pointers
+func mapEquals(a, b map[string]*ravendb.CompareExchangeValue) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		vb, exist := b[k]
+		if exist == false {
+			return false
+		}
+
+		if v != vb {
+			return false
+		}
+	}
+
+	return true
+}
+
 func Test_ravendb_14006(t *testing.T) {
 	driver := createTestDriver(t)
 	destroy := func() { destroyDriver(t, driver) }
 	defer recoverTest(t, destroy)
 
 	compareExchangeValueTrackingInSession(t, driver)
+	compareExchangeValueTrackingInSession_NoTracking(t, driver)
 }

--- a/tests/ravendb_14006_test.go
+++ b/tests/ravendb_14006_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"github.com/ravendb/ravendb-go-client"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+type Company2 struct {
+	Id         string  `json:"Id"`
+	ExternalId string  `json:"ExternalId"`
+	Name       string  `json:"Name"`
+	Address    Address `json:"Address"`
+}
+
+func compareExchangeValueTrackingInSession(t *testing.T, driver *RavenTestDriver) {
+	//ravendb.WithFiddler()
+
+	store := driver.getDocumentStoreMust(t)
+	options := &ravendb.SessionOptions{
+		Database:        "",
+		RequestExecutor: nil,
+		TransactionMode: ravendb.TransactionMode_ClusterWide,
+	}
+
+	{
+		session := openSessionMustWithOptions(t, store, options)
+
+		company := &Company2{Id: "companies/1", ExternalId: "companies/cf", Name: "CF"}
+		session.Store(company)
+
+		numberOfRequest := session.Advanced().GetNumberOfRequests()
+		address := &Address{City: "Torun"}
+
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		_, err = clusterTransaction.CreateCompareExchangeValue(company.ExternalId, address)
+		assert.NoError(t, err)
+
+		assert.Equal(t, numberOfRequest, session.Advanced().GetNumberOfRequests())
+
+		value1, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Address{}), company.ExternalId)
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequest, session.Advanced().GetNumberOfRequests())
+
+		assert.Equal(t, address, value1.GetValue())
+		assert.Equal(t, company.ExternalId, value1.GetKey())
+		assert.Equal(t, int64(0), value1.GetIndex())
+
+		err = session.SaveChanges()
+		assert.NoError(t, err)
+
+		assert.Equal(t, numberOfRequest+1, session.Advanced().GetNumberOfRequests())
+
+		assert.Equal(t, address, value1.GetValue())
+		assert.Equal(t, company.ExternalId, value1.GetKey())
+		assert.True(t, value1.GetIndex() > int64(0))
+
+		value2, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Address{}), company.ExternalId)
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequest+1, session.Advanced().GetNumberOfRequests())
+
+		assert.Equal(t, value1, value2)
+
+		session.SaveChanges()
+		assert.Equal(t, numberOfRequest+1, session.Advanced().GetNumberOfRequests())
+
+		session.Advanced().Clear()
+		value3, err := clusterTransaction.GetCompareExchangeValue(reflect.TypeOf(&Address{}), company.ExternalId)
+		assert.NoError(t, err)
+		assert.Equal(t, value3, value2)
+
+		session.Close()
+	}
+
+	{
+		session := openSessionMustWithOptions(t, store, options)
+		address := &Address{City: "Hadera"}
+
+		ct, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		ct.CreateCompareExchangeValue("companies/hr", address)
+		session.SaveChanges()
+		session.Close()
+	}
+
+	{
+		session := openSessionMustWithOptions(t, store, options)
+		numberOfRequest := session.Advanced().GetNumberOfRequests()
+
+		ct, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		value1, err := ct.GetCompareExchangeValue(reflect.TypeOf(&Address{}), "companies/cf")
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequest+1, session.Advanced().GetNumberOfRequests())
+
+		value2, err := ct.GetCompareExchangeValue(reflect.TypeOf(&Address{}), "companies/hr")
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequest+2, session.Advanced().GetNumberOfRequests())
+
+		values, err := ct.GetCompareExchangeValues(reflect.TypeOf(&Address{}), []string{"companies/cf", "companies/hr"})
+		assert.Equal(t, numberOfRequest+2, session.Advanced().GetNumberOfRequests())
+		assert.Equal(t, 2, len(values))
+		assert.Equal(t, value1, values[value1.GetKey()])
+		assert.Equal(t, value2, values[value2.GetKey()])
+
+		values, err = ct.GetCompareExchangeValues(reflect.TypeOf(&Address{}), []string{"companies/cf", "companies/hr", "companies/hx"})
+		assert.Equal(t, 3, len(values))
+		assert.Equal(t, numberOfRequest+3, session.Advanced().GetNumberOfRequests())
+		assert.Equal(t, value1, values[value1.GetKey()])
+		assert.Equal(t, value2, values[value2.GetKey()])
+
+		value3, err := ct.GetCompareExchangeValue(reflect.TypeOf(&Address{}), "companies/hx")
+		assert.NoError(t, err)
+		assert.Equal(t, numberOfRequest+3, session.Advanced().GetNumberOfRequests())
+
+		assert.Nil(t, value3)
+		assert.Nil(t, values["companies/hx"])
+		err = session.SaveChanges()
+		assert.NoError(t, err)
+
+		address := &Address{City: "Bydgoszcz"}
+		_, err = ct.CreateCompareExchangeValue("companies/hx", address)
+		assert.NoError(t, err)
+		session.SaveChanges()
+		assert.Equal(t, numberOfRequest+4, session.Advanced().GetNumberOfRequests())
+
+		session.Close()
+	}
+}
+
+func Test_ravendb_14006(t *testing.T) {
+	driver := createTestDriver(t)
+	destroy := func() { destroyDriver(t, driver) }
+	defer recoverTest(t, destroy)
+
+	compareExchangeValueTrackingInSession(t, driver)
+}

--- a/tests/ravendb_14989_test.go
+++ b/tests/ravendb_14989_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"github.com/ravendb/ravendb-go-client"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func ravendb14989_should_work(t *testing.T, driver *RavenTestDriver) {
+	store := driver.getDocumentStoreMust(t)
+	{
+		session := openSessionMustWithOptions(t, store, &ravendb.SessionOptions{
+			Database:        "",
+			RequestExecutor: nil,
+			TransactionMode: ravendb.TransactionMode_ClusterWide,
+			DisableAtomicDocumentWritesInClusterWideTransaction: nil,
+		})
+
+		name := "egor"
+		user := &User{
+			Name: &name,
+		}
+
+		clusterTransaction, err := session.Advanced().ClusterTransaction()
+		assert.NoError(t, err)
+
+		clusterTransaction.CreateCompareExchangeValue(strings.Repeat("e", 513), user)
+		assert.NoError(t, err)
+
+		err = session.SaveChanges()
+
+		assert.Error(t, err)
+
+		assert.True(t, strings.Contains(err.Error(), "CompareExchangeKeyTooBigException"))
+	}
+}
+
+func TestRavenDB14989(t *testing.T) {
+	driver := createTestDriver(t)
+	destroy := func() { destroyDriver(t, driver) }
+	defer recoverTest(t, destroy)
+
+	// matches the order of Java tests
+	ravendb14989_should_work(t, driver)
+}

--- a/tests/ravendb_14989_test.go
+++ b/tests/ravendb_14989_test.go
@@ -22,10 +22,9 @@ func ravendb14989_should_work(t *testing.T, driver *RavenTestDriver) {
 			Name: &name,
 		}
 
-		clusterTransaction, err := session.Advanced().ClusterTransaction()
-		assert.NoError(t, err)
+		assert.NotNil(t, session.Advanced().ClusterTransaction())
 
-		clusterTransaction.CreateCompareExchangeValue(strings.Repeat("e", 513), user)
+		_, err := session.Advanced().ClusterTransaction().CreateCompareExchangeValue(strings.Repeat("e", 513), user)
 		assert.NoError(t, err)
 
 		err = session.SaveChanges()

--- a/tests/unique_values_test.go
+++ b/tests/unique_values_test.go
@@ -151,6 +151,16 @@ func uniqueValuesCanListCompareExchange(t *testing.T, driver *RavenTestDriver) {
 
 		v = values["test2"].Value.(*User)
 		assert.Equal(t, *v.Name, "Karmel")
+	}
+
+	{
+		op, err := ravendb.NewGetCompareExchangeValueOperation(reflect.TypeOf(&User{}), "test")
+		assert.NoError(t, err)
+		err = store.Operations().Send(op, nil)
+		assert.NoError(t, err)
+		v, ok := op.Command.Result.Value.(*User)
+		assert.True(t, ok)
+		assert.Equal(t, *v.Name, "Karmel")
 
 	}
 }

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -22,3 +22,7 @@ func (u *User) setName(name string) {
 func (u *User) setLastName(lastName string) {
 	u.LastName = &lastName
 }
+
+func (u *User) setAge(age int) {
+	u.Age = age
+}


### PR DESCRIPTION
Issue: https://issues.hibernatingrhinos.com/issue/RDBC-772/Support-for-cluster-wide-transactions-for-Go-client

Support for:
- cluster wide session
- creating compare exchanges within session
- deleting compare exchanges within session
