### PR TITLE
Allowing the AllowStale property to be set on a PatchByQueryOperation

### DIFF
--- a/delete_by_query_operation.go
+++ b/delete_by_query_operation.go
@@ -62,7 +62,7 @@ func NewDeleteByIndexCommand(conventions *DocumentConventions, queryToDelete *In
 func (c *DeleteByIndexCommand) CreateRequest(node *ServerNode) (*http.Request, error) {
 	options := c.options
 
-	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", options.allowStale)
+	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", options.AllowStale)
 
 	if options.maxOpsPerSecond != 0 {
 		url += "&maxOpsPerSec=" + strconv.Itoa(options.maxOpsPerSecond)

--- a/patch_by_query_operation.go
+++ b/patch_by_query_operation.go
@@ -17,10 +17,17 @@ type PatchByQueryOperation struct {
 	_options       *QueryOperationOptions
 }
 
-func NewPatchByQueryOperation(queryToUpdate string) *PatchByQueryOperation {
-	return &PatchByQueryOperation{
+
+func NewPatchByQueryOperation(queryToUpdate string, opts ...*QueryOperationOptions) *PatchByQueryOperation {
+	op := &PatchByQueryOperation{
 		_queryToUpdate: NewIndexQuery(queryToUpdate),
 	}
+
+	if len(opts) > 0 && opts[0] != nil {
+		op._options = opts[0]
+	}
+
+	return p
 }
 
 func (o *PatchByQueryOperation) GetCommand(store *DocumentStore, conventions *DocumentConventions, cache *httpCache) (RavenCommand, error) {
@@ -62,7 +69,7 @@ func NewPatchByQueryCommand(conventions *DocumentConventions, queryToUpdate *Ind
 func (c *PatchByQueryCommand) CreateRequest(node *ServerNode) (*http.Request, error) {
 	_options := c._options
 
-	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", _options.allowStale)
+	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", _options.AllowStale)
 
 	if _options.maxOpsPerSecond != 0 {
 		url += "&maxOpsPerSec=" + strconv.Itoa(_options.maxOpsPerSecond)

--- a/patch_by_query_operation.go
+++ b/patch_by_query_operation.go
@@ -27,7 +27,7 @@ func NewPatchByQueryOperation(queryToUpdate string, opts ...*QueryOperationOptio
 		op._options = opts[0]
 	}
 
-	return p
+	return op
 }
 
 func (o *PatchByQueryOperation) GetCommand(store *DocumentStore, conventions *DocumentConventions, cache *httpCache) (RavenCommand, error) {

--- a/query_operation_options.go
+++ b/query_operation_options.go
@@ -5,7 +5,7 @@ import "time"
 // QueryOperationOptions represents options for query operation
 type QueryOperationOptions struct {
 	maxOpsPerSecond int
-	allowStale      bool
+	AllowStale      bool
 	staleTimeout    time.Duration
 	retrieveDetails bool
 }


### PR DESCRIPTION
I require the functionality to be able to set the "allowStale" property to be set when executing a custom patch operation, I didnt see this functionality exposed on the current code base. 