### PR TITLE
Expose all `QueryOperationOptions` properties for users.

### DIFF
--- a/delete_by_query_operation.go
+++ b/delete_by_query_operation.go
@@ -62,16 +62,16 @@ func NewDeleteByIndexCommand(conventions *DocumentConventions, queryToDelete *In
 func (c *DeleteByIndexCommand) CreateRequest(node *ServerNode) (*http.Request, error) {
 	options := c.options
 
-	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", options.allowStale)
+	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", options.AllowStale)
 
-	if options.maxOpsPerSecond != 0 {
-		url += "&maxOpsPerSec=" + strconv.Itoa(options.maxOpsPerSecond)
+	if options.MaxOpsPerSecond != 0 {
+		url += "&maxOpsPerSec=" + strconv.Itoa(options.MaxOpsPerSecond)
 	}
 
-	url += fmt.Sprintf("&details=%v", options.retrieveDetails)
+	url += fmt.Sprintf("&details=%v", options.RetrieveDetails)
 
-	if options.staleTimeout != 0 {
-		url += "&staleTimeout=" + durationToTimeSpan(options.staleTimeout)
+	if options.StaleTimeout != 0 {
+		url += "&staleTimeout=" + durationToTimeSpan(options.StaleTimeout)
 	}
 
 	m := jsonExtensionsWriteIndexQuery(c.conventions, c.queryToDelete)

--- a/patch_by_query_operation.go
+++ b/patch_by_query_operation.go
@@ -23,6 +23,13 @@ func NewPatchByQueryOperation(queryToUpdate string) *PatchByQueryOperation {
 	}
 }
 
+func NewPatchByQueryOperationWithOptions(queryToUpdate string, options *QueryOperationOptions) *PatchByQueryOperation {
+	return &PatchByQueryOperation{
+		_queryToUpdate: NewIndexQuery(queryToUpdate),
+		_options:       options,
+	}
+}
+
 func (o *PatchByQueryOperation) GetCommand(store *DocumentStore, conventions *DocumentConventions, cache *httpCache) (RavenCommand, error) {
 	var err error
 	o.Command, err = NewPatchByQueryCommand(conventions, o._queryToUpdate, o._options)
@@ -62,16 +69,16 @@ func NewPatchByQueryCommand(conventions *DocumentConventions, queryToUpdate *Ind
 func (c *PatchByQueryCommand) CreateRequest(node *ServerNode) (*http.Request, error) {
 	_options := c._options
 
-	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", _options.allowStale)
+	url := node.URL + "/databases/" + node.Database + fmt.Sprintf("/queries?allowStale=%v", _options.AllowStale)
 
-	if _options.maxOpsPerSecond != 0 {
-		url += "&maxOpsPerSec=" + strconv.Itoa(_options.maxOpsPerSecond)
+	if _options.MaxOpsPerSecond != 0 {
+		url += "&maxOpsPerSec=" + strconv.Itoa(_options.MaxOpsPerSecond)
 	}
 
-	url += fmt.Sprintf("&details=%v", _options.retrieveDetails)
+	url += fmt.Sprintf("&details=%v", _options.RetrieveDetails)
 
-	if _options.staleTimeout != 0 {
-		url += "&staleTimeout=" + durationToTimeSpan(_options.staleTimeout)
+	if _options.StaleTimeout != 0 {
+		url += "&staleTimeout=" + durationToTimeSpan(_options.StaleTimeout)
 	}
 
 	q := jsonExtensionsWriteIndexQuery(c._conventions, c._queryToUpdate)

--- a/query_operation_options.go
+++ b/query_operation_options.go
@@ -4,8 +4,8 @@ import "time"
 
 // QueryOperationOptions represents options for query operation
 type QueryOperationOptions struct {
-	maxOpsPerSecond int
-	allowStale      bool
-	staleTimeout    time.Duration
-	retrieveDetails bool
+	MaxOpsPerSecond int
+	AllowStale      bool
+	StaleTimeout    time.Duration
+	RetrieveDetails bool
 }


### PR DESCRIPTION
Extending https://github.com/ravendb/ravendb-go-client/pull/206

- exposing all properties form `QueryOperationOptions`
- create `NewPatchByQueryOperation` overload with options